### PR TITLE
Change workflow to matrix-test multiple go versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Run Tests
 
 on:
   push:
@@ -10,8 +10,8 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.21.x']
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        go-version: ['1.19.x', '1.20.x', '1.21.x']
+        platform: [ubuntu-latest]
     
     runs-on: ${{ matrix.platform }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/eduardolat/goeasyi18n
 
-go 1.21.0
+go 1.19
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
Just a small contribution, but testing multiple versions can be useful from time to time.

Change workflow to matrix-test multiple go versions and lower minimum go version for tests.